### PR TITLE
Fixing README example

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ Vue.js Single File Components:
             options: { importLoaders: 1 }
           },
           {
-            loader: 'purgecss-loader',
+            loader: '@fullhuman/purgecss-loader',
             options: {
               content: [
                 path.join(__dirname, 'src/components/**/*.vue')


### PR DESCRIPTION
It's published under `@fullhuman/purgecss-loader` and not `purgecss-loader` and users need to use the package name for Webpack to find the loader.